### PR TITLE
Handle no mutations

### DIFF
--- a/R/SV_incorporation.R
+++ b/R/SV_incorporation.R
@@ -16,15 +16,15 @@ SV_incorporation = function(
   # dmp.dir = '/ifs/work/bergerm1/zhengy1/dmp-2020/mskimpact/'
   # # criteria <- 'permissive'
   # criteria <- 'stringent'
-  # 
+  #
   # DMP fusion calls --------------------------------------------------------
   DMP.fusion <- fread(paste0(dmp.dir,'/data_SV.txt')) %>%
     transmute(DMP_SAMPLE_ID = SampleId,EventType = Sv_Class_Name,Gene1 = Site1_Gene,Gene2 = Site2_Gene,
               Chr1 = Site1_Chrom,Chr2 = Site2_Chrom,Pos1 = Site1_Pos,Pos2 = Site2_Pos,PairedReadCount = Paired_End_Read_Support,
               SplitReadCount = Split_Read_Support,TumorReadCount = Tumor_Read_Count,EventInfo = Annotation) %>% data.table()
-  
+
   # execution ---------------------------------------------------------------
-  
+
   dir.create(paste0(results.dir,'/results_',criteria,'_combined'))
   gene.list <- c('ALK','BRAF','ERBB2','EGFR','FGFR1','FGFR2','FGFR3','KIT','MET','NTRK1','NTRK2','NTRK3','PDGFRA','RET','ROS1')
   access.genes.info <- fread(access.genes,header=F)
@@ -33,23 +33,36 @@ SV_incorporation = function(
   lapply(unique(master.ref$cmo_patient_id),function(x){
     # get sample sheet --------------------------------------------------------
     sample.sheet <- fread(paste0(results.dir,'/',x,'/',x,'_sample_sheet.tsv'))
+
     # get plasma SV calls -----------------------------------------------------
     total.sv <- do.call(rbind,lapply(sample.sheet[Sample_Type == 'duplex']$Sample_Barcode,function(y){
       SV.filename <- master.ref[cmo_sample_id_plasma == y]$sv_path
       if(!file.exists(SV.filename)){stop(paste0('SV file: ',SV.filename,' ----- does not exist'))}
       tmp.SV <- fread(SV.filename) %>% filter(Significance == 'KeyGene')
       return(tmp.SV)
-    })) %>% transmute(TumorId = paste0(TumorId,'___total'),SV_Type,Gene1,Gene2,Chr1,Chr2,Pos1,Pos2,PairedReadCount = PairEndReadSupport,SplitReadCount = SplitReadSupport,TumorReadCount,Fusion) 
-    
+    })) %>%
+      transmute(
+        TumorId = paste0(TumorId,'___total'),
+        SV_Type,Gene1,Gene2,Chr1,Chr2,Pos1,Pos2,PairedReadCount = PairEndReadSupport,
+        SplitReadCount = SplitReadSupport,TumorReadCount,Fusion)
+
     # get DMP SV calls --------------------------------------------------------
     DMP.sv <- do.call(rbind,lapply(sample.sheet[Sample_Type == 'DMP_Tumor']$Sample_Barcode,function(y){
       DMP.fusion[DMP_SAMPLE_ID == y]
-    })) 
+    }))
     if(!is.null(DMP.sv)){
-      DMP.sv <- DMP.sv %>% dplyr::transmute(TumorId = paste0(DMP_SAMPLE_ID,'___DMP_Tumor'),SV_Type = case_when(EventType == 'INVERSION' ~ 'INV',EventType == 'DELETION' ~ 'DEL',
-                                                                                                               EventType == 'INSERTION' ~ 'INS',EventType == 'DUPLICATION' ~ 'DUP',
-                                                                                                               EventType == 'TRANSLOCATION' ~ 'BND',TRUE ~ 'UNKNOWN'),
-                                            Gene1,Gene2,Chr1,Chr2,Pos1,Pos2,PairedReadCount,SplitReadCount,TumorReadCount = NA,Fusion = EventInfo)  
+      DMP.sv <- DMP.sv %>%
+        dplyr::transmute(
+          TumorId = paste0(DMP_SAMPLE_ID,'___DMP_Tumor'),
+          SV_Type = case_when(
+            EventType == 'INVERSION' ~ 'INV',
+            EventType == 'DELETION' ~ 'DEL',
+            EventType == 'INSERTION' ~ 'INS',
+            EventType == 'DUPLICATION' ~ 'DUP',
+            EventType == 'TRANSLOCATION' ~ 'BND',
+            TRUE ~ 'UNKNOWN'),
+          Gene1,Gene2,Chr1,Chr2,Pos1,Pos2,PairedReadCount,
+          SplitReadCount,TumorReadCount = NA,Fusion = EventInfo)
     }else{
       # dummy df if there is no DMP fusion found
       DMP.sv <- data.frame(matrix(nrow = 0,ncol = ncol(DMP.fusion)))
@@ -58,20 +71,20 @@ SV_incorporation = function(
     print('done with reading in')
     print(colnames(total.sv))
     print(colnames(DMP.sv))
-    
+
     # event desc. reconciliating possible DMP vs manta ------------------------
-    rbind(total.sv,DMP.sv) %>% 
+    rbind(total.sv,DMP.sv) %>%
       # consolidate information for dcasting data frame
-      unite(sample_info,PairedReadCount,SplitReadCount,TumorReadCount,sep = '-') %>% unite(gene_pair,Gene1,Gene2,sep = '__') %>% unite(chr_pair,Chr1,Chr2,sep = '__') %>% 
+      unite(sample_info,PairedReadCount,SplitReadCount,TumorReadCount,sep = '-') %>% unite(gene_pair,Gene1,Gene2,sep = '__') %>% unite(chr_pair,Chr1,Chr2,sep = '__') %>%
       # selecting all unique events with their description (manta outputs will be the same, within DMP will be the same)
-      unite(event_info,gene_pair,chr_pair,SV_Type,Pos1,Pos2,sep = '---') %>% select(event_info,Fusion) %>% unique() %>% data.table() -> event.desc 
+      unite(event_info,gene_pair,chr_pair,SV_Type,Pos1,Pos2,sep = '---') %>% select(event_info,Fusion) %>% unique() %>% data.table() -> event.desc
     event.desc <- event.desc[,.(HGVSp_Short = paste0(unique(Fusion),collapse = ' | ')),.(event_info)]
-    
+
     # make into a row ---------------------------------------------------------
     rbind(total.sv,DMP.sv) %>% select(-Fusion) %>%
       # consolidate information for dcasting data frame
-      unite(sample_info,PairedReadCount,SplitReadCount,TumorReadCount,sep = '-') %>% unite(gene_pair,Gene1,Gene2,sep = '__') %>% unite(chr_pair,Chr1,Chr2,sep = '__') %>% 
-      unite(event_info,gene_pair,chr_pair,SV_Type,Pos1,Pos2,sep = '---') %>% spread(TumorId,sample_info) %>% 
+      unite(sample_info,PairedReadCount,SplitReadCount,TumorReadCount,sep = '-') %>% unite(gene_pair,Gene1,Gene2,sep = '__') %>% unite(chr_pair,Chr1,Chr2,sep = '__') %>%
+      unite(event_info,gene_pair,chr_pair,SV_Type,Pos1,Pos2,sep = '---') %>% spread(TumorId,sample_info) %>%
       merge(event.desc,by = 'event_info',all.x = T) %>%
       # parse out information
       separate(event_info,into = c('gene_pair','chr_pair','SV_Type','Pos1','Pos2'),sep = '---') %>%
@@ -81,18 +94,22 @@ SV_incorporation = function(
              DMP = '',duplex_support_num = '',call_confidence = '') %>%
       select(Hugo_Symbol,Chromosome,Start_Position,End_Position,Variant_Classification,HGVSp_Short,Reference_Allele,Tumor_Seq_Allele2,ExAC_AF,Hotspot,DMP,duplex_support_num,call_confidence,everything()) %>%
       data.table() -> SV.table
-    
+
     # adding some annotation columns specific to snv table --------------------
     apply(sample.sheet[Sample_Type != 'plasma_simplex'],1,function(y){
-      current.colname <- paste0(y[which(colnames(sample.sheet) == 'Sample_Barcode')],'___',
-                                case_when(y[which(colnames(sample.sheet) == 'Sample_Type')] == 'duplex' ~'total',
-                                          y[which(colnames(sample.sheet) == 'Sample_Type')] == 'DMP_Tumor' ~'DMP_Tumor',
-                                          y[which(colnames(sample.sheet) == 'Sample_Type')] == 'DMP_Normal' ~'DMP_Normal',
-                                          y[which(colnames(sample.sheet) == 'Sample_Type')] == 'unfilterednormal' ~'unfilterednormal'))
+      current.colname <- paste0(
+        y[which(colnames(sample.sheet) == 'Sample_Barcode')],
+        '___',
+        case_when(y[which(colnames(sample.sheet) == 'Sample_Type')] == 'duplex' ~'total',
+                  y[which(colnames(sample.sheet) == 'Sample_Type')] == 'DMP_Tumor' ~'DMP_Tumor',
+                  y[which(colnames(sample.sheet) == 'Sample_Type')] == 'DMP_Normal' ~'DMP_Normal',
+                  y[which(colnames(sample.sheet) == 'Sample_Type')] == 'unfilterednormal' ~'unfilterednormal'))
+
       # If any of the sample does not already have a column
       if(!current.colname %in% colnames(SV.table)){
         SV.table[,eval(current.colname) := NA]
       }
+
       # only for plasma sample -- '.called' column
       if(y[which(colnames(sample.sheet) == 'Sample_Type')] == 'duplex'){
         SV.table[,paste0(y[which(colnames(sample.sheet) == 'Sample_Barcode')],'___duplex.called') := case_when(
@@ -101,25 +118,31 @@ SV_incorporation = function(
           T ~ 'Called'
         )]
       }
+
       # edit DMP signout column
       if(y[which(colnames(sample.sheet) == 'Sample_Type')] == 'DMP_Tumor'){
-        SV.table[!is.na(get(current.colname)),DMP := 'Signed out'] 
+        SV.table[!is.na(get(current.colname)),DMP := 'Signed out']
       }
     })
     # adding CH filler column
     SV.table$CH = ''
-    
+
     # append and write --------------------------------------------------------
     tmp.snv.table.path = paste0(results.dir,'/results_',criteria,'/',x,'_SNV_table.csv')
     if(!file.exists(tmp.snv.table.path)){
       stop(paste0(tmp.snv.table.path,' does not exist. Check if filter_calls was run correcly'))
     }
     SNV.table <- fread(tmp.snv.table.path)
-    snv.sv.table.directory <- paste0(results.dir,'/results_',criteria,'_combined/',x,'_table.csv') 
-    write.csv(rbind(SNV.table,SV.table),snv.sv.table.directory,quote = F,row.names = F)
+
+    snv.sv.table.directory <- paste0(results.dir,'/results_',criteria,'_combined/',x,'_table.csv')
     
+    if (nrow(SNV.table) == 0) {
+      write.csv(SV.table,snv.sv.table.directory,quote = F,row.names = F)
+    } else {
+      write.csv(rbind(SNV.table,SV.table),snv.sv.table.directory,quote = F,row.names = F)
+    }
   })
-  
+
 }
 
 # Executable -----------------------------------------------------------------------------------------------------------
@@ -132,7 +155,7 @@ suppressPackageStartupMessages({
 })
 
 if (!interactive()) {
-  
+
   parser=ArgumentParser()
   parser$add_argument('-m', '--masterref', type='character', help='File path to master reference file')
   parser$add_argument('-o', '--resultsdir', type='character', help='Output directory')
@@ -143,21 +166,20 @@ if (!interactive()) {
   parser$add_argument('-c', '--criteria', type='character', default = 'stringent',
                       help='Calling criteria [default]')
   args=parser$parse_args()
-  
+
   master.ref = args$masterref
   results.dir = args$resultsdir
   dmpdir = args$dmpdir
   access.genes=args$genelist
   criteria = args$criteria
-  
+
   cat(paste0(paste0(c(paste0(rep('-',15),collapse = ''),'Arguments input: ',master.ref,results.dir,dmpdir,access.genes,criteria,
                       paste0(rep('-',15),collapse = '')),collapse = "\n"),'\n'))
-  
+
   if(!criteria %in% c('stringent','permissive')){
     stop('Criteria argument should be either stringent or permissive')
   }
-  
-  suppressWarnings(SV_incorporation(fread(master.ref),results.dir,dmpdir,access.genes,criteria))
-  
-}
 
+  suppressWarnings(SV_incorporation(fread(master.ref),results.dir,dmpdir,access.genes,criteria))
+
+}

--- a/R/filter_calls.R
+++ b/R/filter_calls.R
@@ -169,7 +169,19 @@ filter_calls = function(
         data.table()
     } else {
       # if fillouts.dt has no data, then add the needed columns with no data
-      fillouts.dt[,c("DMP", "Hotspot", "duplex_support_num") := NA]
+      fillouts.dt[,c("DMP", "Hotspot", "duplex_support_num", "call_confidence", "CH") := NA]
+
+      fillouts.dt <- fillouts.dt %>% select(
+        Hugo_Symbol,Chromosome,Start_Position,End_Position,
+        Variant_Classification,HGVSp_Short,Reference_Allele,Tumor_Seq_Allele2,
+        ExAC_AF,Hotspot,DMP,CH,duplex_support_num,call_confidence,sort(everything()))
+
+      write.csv(
+        fillouts.dt,
+        paste0(results.dir,'/results_',criteria,'/',x,'_SNV_table.csv'),
+        row.names = F)
+      
+      return()
     }
 
     # Interesting cases where DMP signed out calls are artifacets
@@ -185,23 +197,6 @@ filter_calls = function(
       # paste0(gsub('duplex','simplex',plasma.samples),'.called')
 
     ) := 'Not Called']
-
-    # check if the table is emtpy, if so then add the remaining columns and exit
-
-    if (nrow(fillouts.dt) == 0) {
-      fillouts.dt[,c("call_confidence", "CH") := NA]
-
-      fillouts.dt <- fillouts.dt %>% select(
-        Hugo_Symbol,Chromosome,Start_Position,End_Position,
-        Variant_Classification,HGVSp_Short,Reference_Allele,Tumor_Seq_Allele2,
-        ExAC_AF,Hotspot,DMP,CH,duplex_support_num,call_confidence,sort(everything()))
-
-      write.csv(
-        fillouts.dt,
-        paste0(results.dir,'/results_',criteria,'/',x,'_SNV_table.csv'),
-        row.names = F)
-      return
-    }
 
     # preliminary calling
     # tmp.col.name <- plasma.samples[1]

--- a/R/filter_calls.R
+++ b/R/filter_calls.R
@@ -168,6 +168,9 @@ filter_calls = function(
         mutate(DMP = NA) %>%
         data.table()
     } else {
+
+      print(paste0("Found no tumor or DMP mutations for ", x, ". Writing an empty data.frame to CSV."))
+
       # if fillouts.dt has no data, then add the needed columns with no data
       fillouts.dt[,c("DMP", "Hotspot", "duplex_support_num", "call_confidence", "CH") := NA]
 
@@ -180,7 +183,7 @@ filter_calls = function(
         fillouts.dt,
         paste0(results.dir,'/results_',criteria,'/',x,'_SNV_table.csv'),
         row.names = F)
-      
+
       return()
     }
 

--- a/R/filter_calls.R
+++ b/R/filter_calls.R
@@ -16,7 +16,7 @@ filter_calls = function(
   # CH.calls = fread('/ifs/work/bergerm1/zhengy1/RET_all/Original_files/signedout_CH.txt')
   # # criteria <- 'permissive'
   # criteria <- 'stringent'
-  # 
+  #
   # criteria definition -----------------------------------------------------
   if(criteria == 'permissive'){
     hotspot.support <- 1
@@ -25,99 +25,184 @@ filter_calls = function(
     hotspot.support <- 3
     non.hotspot.support <- 5
   }
-  
+
   dir.create(paste0(results.dir,'/results_',criteria))
-  
+
   # inputs ---------------------------------------------------------------
   # DMP.key <- fread(dmp.key.path)
   CH.calls = fread(CH.path)
   pooled.normal.mafs <-
-    fread(paste0(results.dir,'/pooled/all_all_unique.maf')) %>% mutate(Tumor_Sample_Barcode = paste0(Tumor_Sample_Barcode,'___pooled')) %>%
-    select(Hugo_Symbol,Tumor_Sample_Barcode,Chromosome,Start_Position,End_Position,Variant_Classification,HGVSp_Short,Reference_Allele,Tumor_Seq_Allele2,t_alt_count) %>% 
-    group_by(Hugo_Symbol,Chromosome,Start_Position,End_Position,Variant_Classification,Reference_Allele,Tumor_Seq_Allele2) %>% 
-    summarise(duplex_support_num = length(which(t_alt_count >= 2))) %>% filter(duplex_support_num > 0,.preserve = T) %>% data.table()
-  
+    fread(paste0(results.dir,'/pooled/all_all_unique.maf')) %>%
+    mutate(Tumor_Sample_Barcode = paste0(Tumor_Sample_Barcode,'___pooled')) %>%
+    select(Hugo_Symbol,Tumor_Sample_Barcode,Chromosome,Start_Position,End_Position,Variant_Classification,HGVSp_Short,Reference_Allele,Tumor_Seq_Allele2,t_alt_count) %>%
+    group_by(Hugo_Symbol,Chromosome,Start_Position,End_Position,Variant_Classification,Reference_Allele,Tumor_Seq_Allele2) %>%
+    summarise(duplex_support_num = length(which(t_alt_count >= 2))) %>%
+    filter(duplex_support_num > 0,.preserve = T) %>%
+    data.table()
+
   # for each patient produce the correct results ----------------------------
   # x <- unique(master.ref$cmo_patient_id)[1]
   all.fillout.dim <- lapply(unique(master.ref$cmo_patient_id),function(x){
     print(paste0('Processing patient ',x))
+
     # Inputs and sanity checks ------------------------------------------------
     fillouts.filenames <- list.files(paste0(results.dir,'/',x,'/'),'ORG-STD_genotyped.maf|ORG-SIMPLEX-DUPLEX_genotyped.maf',full.names = T)
+
     # compiling a sample sheet with duplex, simplex, normal, DMP tumor and DMP normal
     sample.sheet <- fread(paste0(results.dir,'/',x,'/',x,'_sample_sheet.tsv'))[,.(Sample_Barcode,cmo_patient_id,Sample_Type)]
     simplex.sample.sheet = sample.sheet[Sample_Type == 'duplex',.(Sample_Barcode,cmo_patient_id,Sample_Type = 'simplex')]
-    sample.sheet = rbind(sample.sheet,simplex.sample.sheet) %>% mutate(column.names = paste0(Sample_Barcode,'___',Sample_Type)) %>% data.table()
-    # compiling different genotyp files from step 1
+    sample.sheet = rbind(sample.sheet,simplex.sample.sheet) %>%
+      mutate(column.names = paste0(Sample_Barcode,'___',Sample_Type)) %>%
+      data.table()
+
+    # compiling different genotype files from step 1
     fillouts.dt <- do.call(rbind,lapply(fillouts.filenames,function(y){
       sample.name = gsub('.*./|-ORG.*.','',y)
       sample.type = sample.sheet[Sample_Barcode == sample.name]$Sample_Type
+
       # t_alt_count,t_ref_count,t_depth these columns are useless, have to use duplex/simplex/standard columms
-      maf.file <- fread(y) %>% select(-c(t_alt_count,t_ref_count)) %>% data.table()
+      maf.file <- fread(y) %>%
+        select(-c(t_alt_count,t_ref_count)) %>%
+        data.table()
+
+      if (nrow(maf.file) == 0) {
+
+        columns <- c(
+          "Hugo_Symbol", "Tumor_Sample_Barcode", "Chromosome", "Start_Position",
+          "End_Position", "Variant_Classification", "HGVSp_Short",
+          "Reference_Allele", "Tumor_Seq_Allele2", "t_var_freq", "ExAC_AF")
+        df <- data.frame(matrix(ncol = length(columns), nrow = 0))
+        colnames(df) <- columns
+
+        return(df)
+      }
+
       # fragment counts replacing actual allele counts
       if(grepl('SIMPLEX-DUPLEX_genotyped',y)){
         melt.id.vars = colnames(maf.file)[!grepl('fragment',colnames(maf.file))]
+
         # get rid of simplex duplex aggregate columns
-        maf.file %>% select(-c(contains('simplex_duplex'))) %>%
+        maf.file %>%
+          select(-c(contains('simplex_duplex'))) %>%
           # melting and dcasting columns back but separating duplex and simplex columns
           # t_alt_duplex, t_depth_duplex, t_alt_simplex, t_depth_simplex --> t_alt, t_depth
           melt.data.table(id.vars = melt.id.vars,variable.name = 'variable',value.name = 'value') %>%
-          mutate(variable = gsub('fragment','_',variable)) %>% separate(variable,c('variable','Sample_Type'),sep = '___') %>%
-          mutate(Tumor_Sample_Barcode = paste0(sample.name,'___',Sample_Type)) %>% select(-Sample_Type) %>% data.table() %>%
+          mutate(variable = gsub('fragment','_',variable)) %>%
+          separate(variable,c('variable','Sample_Type'),sep = '___') %>%
+          mutate(Tumor_Sample_Barcode = paste0(sample.name,'___',Sample_Type)) %>%
+          select(-Sample_Type) %>%
+          data.table() %>%
           unique() %>%
           dcast.data.table(as.formula(paste0(paste0(melt.id.vars,collapse = ' + '),' ~ variable')),value.var = 'value') -> maf.file
       }else{
-        maf.file <- maf.file %>% mutate(Tumor_Sample_Barcode = paste0(sample.name,'___',sample.type)) %>%
+        maf.file <- maf.file %>%
+          mutate(Tumor_Sample_Barcode = paste0(sample.name,'___',sample.type)) %>%
           # swaping the t_alt_count(etc)_standard for t_alt_count(etc)
           mutate(t_alt_count = t_alt_count_standard,t_total_count = t_total_count_standard)
       }
-      maf.file = maf.file %>% mutate(t_var_freq = paste0(t_alt_count,'/',t_total_count,'(',round(t_alt_count/t_total_count,4),')')) %>% 
+
+      maf.file = maf.file %>%
+        mutate(t_var_freq = paste0(t_alt_count,'/',t_total_count,'(',round(t_alt_count/t_total_count,4),')')) %>%
         transmute(Hugo_Symbol,Tumor_Sample_Barcode,Chromosome = as.character(Chromosome),Start_Position,End_Position,Variant_Classification,
-                  HGVSp_Short,Reference_Allele,Tumor_Seq_Allele2,t_var_freq,ExAC_AF) %>% data.table()
+                  HGVSp_Short,Reference_Allele,Tumor_Seq_Allele2,t_var_freq,ExAC_AF) %>%
+        data.table()
+
       return(maf.file)
-    })) %>% unique() %>% data.table()
+    })) %>%
+      unique() %>%
+      data.table()
+
     # merging and melting -----------------------------------------------------
-    hotspot.maf <- fread(paste0(results.dir,'/',x,'/',x,'_all_unique_calls_hotspots.maf')) %>% rowwise() %>%
+    hotspot.maf <- fread(paste0(results.dir,'/',x,'/',x,'_all_unique_calls_hotspots.maf')) %>%
+      rowwise() %>%
       transmute(Hugo_Symbol,Chromosome = as.character(Chromosome),Start_Position,End_Position,Variant_Classification,
                 # HGVSp_Short,
-                Reference_Allele,Tumor_Seq_Allele2,Hotspot = ifelse(hotspot_whitelist,'Hotspot',NA)) %>% data.table()
+                Reference_Allele,Tumor_Seq_Allele2,Hotspot = ifelse(hotspot_whitelist,'Hotspot',NA)) %>%
+      data.table()
+
     dmp.maf <- fread(paste0(results.dir,'/',x,'/',x,'_impact_calls.maf')) %>%
       transmute(Hugo_Symbol,Chromosome = as.character(Chromosome),Start_Position,End_Position,Variant_Classification,
                 # HGVSp_Short,
-                Reference_Allele,Tumor_Seq_Allele2) %>% mutate(DMP = 'Signed out') %>% unique() %>% data.table()
-    
-    if(nrow(dmp.maf) > 0){
-        fillouts.dt <- fillouts.dt %>% dcast.data.table(Hugo_Symbol + Chromosome + Start_Position + End_Position + Variant_Classification + 
-                                                              HGVSp_Short + Reference_Allele + Tumor_Seq_Allele2 + ExAC_AF ~ Tumor_Sample_Barcode,
-                                                            value.var = 't_var_freq') %>%
-              # hotspot information 
-              merge(hotspot.maf,by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),all.x = T) %>%
-              # Identifying signed out calls
-              merge(dmp.maf,by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),all.x = T) %>%
-              # pooled normal for systemic artifacts
-              merge(pooled.normal.mafs,by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),all.x = T) %>% data.table()
-    }else{
-      fillouts.dt <- fillouts.dt %>% dcast.data.table(Hugo_Symbol + Chromosome + Start_Position + End_Position + Variant_Classification + 
-                                                      HGVSp_Short + Reference_Allele + Tumor_Seq_Allele2 + ExAC_AF ~ Tumor_Sample_Barcode,
-                                                    value.var = 't_var_freq') %>%
-        # hotspot information 
-        merge(hotspot.maf,by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),all.x = T) %>%
+                Reference_Allele,Tumor_Seq_Allele2) %>%
+      mutate(DMP = 'Signed out') %>%
+      unique() %>%
+      data.table()
+
+    if((nrow(dmp.maf) > 0) && (nrow(fillouts.dt) > 0)){
+        fillouts.dt <- fillouts.dt %>%
+          dcast.data.table(Hugo_Symbol + Chromosome + Start_Position + End_Position + Variant_Classification +
+                           HGVSp_Short + Reference_Allele + Tumor_Seq_Allele2 + ExAC_AF ~ Tumor_Sample_Barcode,
+                           value.var = 't_var_freq') %>%
+          # hotspot information
+          merge(
+            hotspot.maf,
+            by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),
+            all.x = T) %>%
+          # Identifying signed out calls
+          merge(
+            dmp.maf,
+            by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),
+            all.x = T) %>%
+          # pooled normal for systemic artifacts
+          merge(
+            pooled.normal.mafs,
+            by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),
+            all.x = T) %>%
+          data.table()
+    } else if (nrow(fillouts.dt) > 0){
+      fillouts.dt <- fillouts.dt %>%
+        dcast.data.table(
+          Hugo_Symbol + Chromosome + Start_Position + End_Position + Variant_Classification +
+          HGVSp_Short + Reference_Allele + Tumor_Seq_Allele2 + ExAC_AF ~ Tumor_Sample_Barcode,
+          value.var = 't_var_freq') %>%
+        # hotspot information
+        merge(
+          hotspot.maf,
+          by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),
+          all.x = T) %>%
         # pooled normal for systemic artifacts
-        merge(pooled.normal.mafs,by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),all.x = T) %>% 
-        mutate(DMP = NA) %>% data.table()
+        merge(
+          pooled.normal.mafs,
+          by = c('Hugo_Symbol','Chromosome','Start_Position','End_Position','Variant_Classification','Reference_Allele','Tumor_Seq_Allele2'),
+          all.x = T) %>%
+        mutate(DMP = NA) %>%
+        data.table()
+    } else {
+      # if fillouts.dt has no data, then add the needed columns with no data
+      fillouts.dt[,c("DMP", "Hotspot", "duplex_support_num") := NA]
     }
-    
+
     # Interesting cases where DMP signed out calls are artifacets
     if(any(!is.na(fillouts.dt$DMP) & !is.na(fillouts.dt$duplex_support_num))){
       print(paste0('Look at ',x,' for DMP signed out plasma artifacts...'))
     }
+
     # germline filtering for matched and unmatched ----------------------------
     plasma.samples <- sample.sheet[Sample_Type %in% c('duplex')]$column.names
     normal.samples <- sample.sheet[Sample_Type %in% c('unfilterednormal','normal_DMP')]$column.names
     fillouts.dt[,c(
       paste0(plasma.samples,'.called')
       # paste0(gsub('duplex','simplex',plasma.samples),'.called')
-      
+
     ) := 'Not Called']
+
+    # check if the table is emtpy, if so then add the remaining columns and exit
+
+    if (nrow(fillouts.dt) == 0) {
+      fillouts.dt[,c("call_confidence", "CH") := NA]
+
+      fillouts.dt <- fillouts.dt %>% select(
+        Hugo_Symbol,Chromosome,Start_Position,End_Position,
+        Variant_Classification,HGVSp_Short,Reference_Allele,Tumor_Seq_Allele2,
+        ExAC_AF,Hotspot,DMP,CH,duplex_support_num,call_confidence,sort(everything()))
+
+      write.csv(
+        fillouts.dt,
+        paste0(results.dir,'/results_',criteria,'/',x,'_SNV_table.csv'),
+        row.names = F)
+      return
+    }
+
     # preliminary calling
     # tmp.col.name <- plasma.samples[1]
     lapply(plasma.samples,function(tmp.col.name){
@@ -135,6 +220,7 @@ filter_calls = function(
       # c(eval(paste0(tmp.col.name,'.called')),eval(paste0(gsub('duplex','simplex',tmp.col.name),'.called'))) := list('Called','Called')]
       # print(table(fillouts.dt[,get(paste0(tmp.col.name,'.called'))]))
     })
+
     if(all(!c('unfilterednormal','normal_DMP') %in% sample.sheet$Sample_Type)){
       tmp.col.name <- plasma.samples[1]
       lapply(plasma.samples,function(tmp.col.name){
@@ -154,12 +240,12 @@ filter_calls = function(
         })
       })
     }
-    
+
     # final processing --------------------------------------------------------
     # Save only the useful column
     #print(fillouts.dt)
     #print("#######")
-    fillouts.dt <-  fillouts.dt[DMP == 'Signed out' | fillouts.dt[,apply(.SD,1,function(x){any(x == 'Called')})]] 
+    fillouts.dt <-  fillouts.dt[DMP == 'Signed out' | fillouts.dt[,apply(.SD,1,function(x){any(x == 'Called')})]]
     #print(fillouts.dt)
     # combining duplex and simplex counts
     lapply(plasma.samples,function(tmp.col.name){
@@ -172,10 +258,11 @@ filter_calls = function(
       )]
       fillouts.dt[,c(eval(gsub('duplex','simplex',tmp.col.name)),eval(tmp.col.name)):= list(NULL,NULL)]
     })
-    fillouts.dt <- fillouts.dt[,order(colnames(fillouts.dt)),with = F] %>% 
+
+    fillouts.dt <- fillouts.dt[,order(colnames(fillouts.dt)),with = F] %>%
       # filter for artifacts
       mutate(call_confidence = case_when(
-        (Hugo_Symbol == 'TERT' & is.na(Hotspot)) | (Hugo_Symbol == 'ERBB2' & grepl('[A-Z]90[0-9][A-Z]',HGVSp_Short)) | 
+        (Hugo_Symbol == 'TERT' & is.na(Hotspot)) | (Hugo_Symbol == 'ERBB2' & grepl('[A-Z]90[0-9][A-Z]',HGVSp_Short)) |
           (Hugo_Symbol == 'BRAF' & grepl('711',HGVSp_Short)) | (Hugo_Symbol == 'NF1' & grepl('[A-Z]106[0-9][A-Z]',HGVSp_Short)) ~ 'Low',
         DMP == 'Signed out' ~ 'High',
         TRUE ~ ''
@@ -185,15 +272,15 @@ filter_calls = function(
             all.x = T) %>%
       mutate(CH = ifelse(is.na(CH),'No','Yes')) %>%
       select(Hugo_Symbol,Chromosome,Start_Position,End_Position,Variant_Classification,HGVSp_Short,Reference_Allele,Tumor_Seq_Allele2,
-             ExAC_AF,Hotspot,DMP,CH,duplex_support_num,call_confidence,sort(everything())) 
-    
+             ExAC_AF,Hotspot,DMP,CH,duplex_support_num,call_confidence,sort(everything()))
+
     write.csv(fillouts.dt,paste0(results.dir,'/results_',criteria,'/',x,'_SNV_table.csv'),row.names = F)
   })
-  
+
   if(all(unlist(all.fillout.dim))){
     print('All dimension of  fillout mafs for each patient looks correct')
   }
-  
+
 }
 
 # Executable -----------------------------------------------------------------------------------------------------------
@@ -206,7 +293,7 @@ suppressPackageStartupMessages({
 })
 
 if (!interactive()) {
-  
+
   parser=ArgumentParser()
   parser$add_argument('-m', '--masterref', type='character', help='File path to master reference file')
   parser$add_argument('-o', '--resultsdir', type='character', help='Output directory')
@@ -220,14 +307,14 @@ if (!interactive()) {
   results.dir = args$resultsdir
   chlist = args$chlist
   criteria = args$criteria
-  
+
   cat(paste0(paste0(c(paste0(rep('-',15),collapse = ''),'Arguments input: ',master.ref,results.dir,chlist,criteria,
                       paste0(rep('-',15),collapse = '')),collapse = "\n"),'\n'))
-  
+
   if(!criteria %in% c('stringent','permissive')){
     stop('Criteria argument should be either stringent or permissive')
   }
-  
+
   suppressWarnings(filter_calls(fread(master.ref),results.dir,chlist,criteria))
-  
+
 }


### PR DESCRIPTION
I made two main sets of changes. And I successfully tested all my changes with samples that had no mutations using the `filer_calls.R` and `SV_incorporation.R` scripts.

## First set of changes
I made some changes to correspond with the changes I made in the genotype_variants PR earlier today. `filter_calls.R` now handles tumor samples that have no mutations AND meets one of the following conditions:

- it has no DMP sample
- it has a DMP sample, but it has no mutations.

Not sure if the way I did it is the best, but for those samples with no mutations I have the `filter_calls.R` script output a CSV for the patient with the usual columns, except ones like these:
- C-028ECD-L001-d___duplex.called
- C-028ECD-L001-d___total
- C-028ECD-N001-d___unfilterednormal
- P-0038961-T01-IM6___DMP_Tumor
- etc.

I also changed the `SV_incorporation.R` script so it handles the case of samples with no mutations.

## Second set of changes
I also move the code around a bit to make it a bit more readable (in my eyes at least).
